### PR TITLE
Fix: isInstaller() for GooglePlay crashes when the passed context class is not from the root package.

### DIFF
--- a/samples/life_openiab/src/org/onepf/life2/oms/appstore/GooglePlay.java
+++ b/samples/life_openiab/src/org/onepf/life2/oms/appstore/GooglePlay.java
@@ -64,7 +64,7 @@ public class GooglePlay implements Appstore {
             return true;
         }
         PackageManager packageManager = mContext.getPackageManager();
-        String packageName = mContext.getClass().getPackage().getName();
+        String packageName = mContext.getApplicationContext().getClass().getPackage().getName();
         String installerPackageName = packageManager.getInstallerPackageName(packageName);
         return (installerPackageName != null && installerPackageName.equals(ANDROID_INSTALLER));
     }


### PR DESCRIPTION
Under the conditions described in the title, isInstaller() will crash with the following exception:

``` java
05-20 09:13:54.851: E/AndroidRuntime(32389): Caused by: java.lang.IllegalArgumentException: Unknown package: com.something.activity
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.os.Parcel.readException(Parcel.java:1429)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.os.Parcel.readException(Parcel.java:1379)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.content.pm.IPackageManager$Stub$Proxy.getInstallerPackageName(IPackageManager.java:2413)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.app.ApplicationPackageManager.getInstallerPackageName(ApplicationPackageManager.java:1118)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at org.onepf.openiab.appstore.GooglePlay.isInstaller(GooglePlay.java:67)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at org.onepf.openiab.AppstoreServiceManager.getInstallerAppstore(AppstoreServiceManager.java:146)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at org.onepf.openiab.AppstoreServiceManager.getAppstoreForService(AppstoreServiceManager.java:128)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at org.onepf.openiab.OpenIabHelper$1.onAppstoreServiceManagerInitFinishedListener(OpenIabHelper.java:85)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at org.onepf.openiab.AppstoreServiceManager.startSetup(AppstoreServiceManager.java:68)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at org.onepf.openiab.OpenIabHelper.startSetup(OpenIabHelper.java:82)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at com.something.billing.GooglePlayHelper.<init>(GooglePlayHelper.java:31)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at com.something.billing.BillingHelper.<init>(BillingHelper.java:61)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at com.something.activity.StripePreviewActivity.onCreate(SomeActivity.java:55)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.app.Activity.performCreate(Activity.java:5158)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1080)
05-20 09:13:54.851: E/AndroidRuntime(32389):    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2266)
05-20 09:13:54.851: E/AndroidRuntime(32389):    ... 11 more
```

which is perfectly understandable, as it checks for a subpackage being installed and not the root (app) package.

This commit fixes the problem.
