### PR TITLE
Hide library output into logcat.

### DIFF
--- a/library/src/org/onepf/oms/appstore/AmazonAppstore.java
+++ b/library/src/org/onepf/oms/appstore/AmazonAppstore.java
@@ -29,6 +29,7 @@ import android.util.Log;
  * Date: 16.04.13
  */
 public class AmazonAppstore extends DefaultAppstore {
+    private static final boolean mDebugLog = false;
     private static final String TAG = AmazonAppstore.class.getSimpleName();
     
     private volatile Boolean sandboxMode;// = false;
@@ -43,7 +44,7 @@ public class AmazonAppstore extends DefaultAppstore {
 
     @Override
     public boolean isPackageInstaller(String packageName) {
-        Log.d(TAG, "isPackageInstaller() packageName: " + packageName);
+        if (mDebugLog) Log.d(TAG, "isPackageInstaller() packageName: " + packageName);
         if (sandboxMode != null) {
             return !sandboxMode;
         }
@@ -53,11 +54,11 @@ public class AmazonAppstore extends DefaultAppstore {
                 localClassLoader.loadClass("com.amazon.android.Kiwi");
                 sandboxMode = false;
             } catch (Throwable localThrowable) {
-                Log.d(TAG, "isPackageInstaller() cannot load class com.amazon.android.Kiwi ");
+                if (mDebugLog) Log.d(TAG, "isPackageInstaller() cannot load class com.amazon.android.Kiwi ");
                 sandboxMode = true;
             }
         }
-        Log.d(TAG, "isPackageInstaller() sandBox: " + sandboxMode);
+        if (mDebugLog) Log.d(TAG, "isPackageInstaller() sandBox: " + sandboxMode);
         return !sandboxMode;
     }
 

--- a/library/src/org/onepf/oms/appstore/AmazonAppstoreBillingService.java
+++ b/library/src/org/onepf/oms/appstore/AmazonAppstoreBillingService.java
@@ -55,6 +55,7 @@ import com.amazon.inapp.purchasing.SubscriptionPeriod;
  * @since 16.04.13
  */
 public class AmazonAppstoreBillingService extends BasePurchasingObserver implements AppstoreInAppBillingService {
+    private static final boolean mDebugLog = false;
     private static final String TAG = AmazonAppstoreBillingService.class.getSimpleName();
     
     private Map<String, IabHelper.OnIabPurchaseFinishedListener> mRequestListeners = new HashMap<String, IabHelper.OnIabPurchaseFinishedListener>();
@@ -89,24 +90,24 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
 
     @Override
     public void onSdkAvailable(final boolean isSandboxMode) {
-        Log.v(TAG, "onSdkAvailable() isSandBox: " + isSandboxMode);
+        if (mDebugLog) Log.v(TAG, "onSdkAvailable() isSandBox: " + isSandboxMode);
         PurchasingManager.initiateGetUserIdRequest();
     }
 
     @Override
     public void onGetUserIdResponse(final GetUserIdResponse userIdResponse) {
-        Log.d(TAG, "onGetUserIdResponse() reqId: " + userIdResponse.getRequestId() + ", status: " + userIdResponse.getUserIdRequestStatus());
+        if (mDebugLog) Log.d(TAG, "onGetUserIdResponse() reqId: " + userIdResponse.getRequestId() + ", status: " + userIdResponse.getUserIdRequestStatus());
 
         if (userIdResponse.getUserIdRequestStatus() == GetUserIdResponse.GetUserIdRequestStatus.SUCCESSFUL) {
             final String userId = userIdResponse.getUserId();
-            Log.d(TAG, "Set current userId: " + userId);
+            if (mDebugLog) Log.d(TAG, "Set current userId: " + userId);
             this.currentUserId = userId;
             if (setupListener != null) {
                 setupListener.onIabSetupFinished(new IabResult(IabHelper.BILLING_RESPONSE_RESULT_OK, "Setup successful."));
                 setupListener = null;
             }
         } else {
-            Log.d(TAG, "onGetUserIdResponse() Unable to get user ID");
+            if (mDebugLog) Log.d(TAG, "onGetUserIdResponse() Unable to get user ID");
             if (setupListener != null) {
                 setupListener.onIabSetupFinished(new IabResult(IabHelper.BILLING_RESPONSE_RESULT_ERROR, "Unable to get userId"));
                 setupListener = null;
@@ -116,7 +117,7 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
     
     @Override
     public Inventory queryInventory(boolean querySkuDetails, List<String> moreItemSkus, List<String> moreSubsSkus) {
-        Log.d(TAG, "queryInventory() querySkuDetails: " + querySkuDetails+ " moreItemSkus: " + moreItemSkus+ " moreSubsSkus: " + moreSubsSkus);
+        if (mDebugLog) Log.d(TAG, "queryInventory() querySkuDetails: " + querySkuDetails+ " moreItemSkus: " + moreItemSkus+ " moreSubsSkus: " + moreSubsSkus);
         inventory = new Inventory();
         inventoryLatch = new CountDownLatch(1);
         PurchasingManager.initiatePurchaseUpdatesRequest(Offset.BEGINNING);
@@ -143,26 +144,26 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
                 try {
                     inventoryLatch.await();
                 } catch (InterruptedException e) {
-                    Log.w(TAG, "queryInventory() SkuDetails fetching interrupted");
+                    if (mDebugLog) Log.w(TAG, "queryInventory() SkuDetails fetching interrupted");
                 }
             }
         }
-        Log.d(TAG, "queryInventory() finished. Inventory size: " + inventory.getAllOwnedSkus().size());
+        if (mDebugLog) Log.d(TAG, "queryInventory() finished. Inventory size: " + inventory.getAllOwnedSkus().size());
         return inventory;
     }
 
     @Override
     public void onPurchaseUpdatesResponse(final PurchaseUpdatesResponse purchaseUpdatesResponse) {
-        Log.v(TAG, "onPurchaseUpdatesResponse() reqStatus: " + purchaseUpdatesResponse.getPurchaseUpdatesRequestStatus() + "reqId: " + purchaseUpdatesResponse.getRequestId());
+        if (mDebugLog) Log.v(TAG, "onPurchaseUpdatesResponse() reqStatus: " + purchaseUpdatesResponse.getPurchaseUpdatesRequestStatus() + "reqId: " + purchaseUpdatesResponse.getRequestId());
         
         if (!purchaseUpdatesResponse.getUserId().equals(currentUserId)) {
-            Log.w(TAG, "onPurchaseUpdatesResponse() Current UserId: " + currentUserId + ", purchase UserId: " + purchaseUpdatesResponse.getUserId());
+            if (mDebugLog) Log.w(TAG, "onPurchaseUpdatesResponse() Current UserId: " + currentUserId + ", purchase UserId: " + purchaseUpdatesResponse.getUserId());
             inventoryLatch.countDown();
             return;
         }
         // TODO: do something with this
         for (final String sku : purchaseUpdatesResponse.getRevokedSkus()) {
-            Log.v(TAG, "Revoked Sku:" + sku);
+            if (mDebugLog) Log.v(TAG, "Revoked Sku:" + sku);
         }
 
         switch (purchaseUpdatesResponse.getPurchaseUpdatesRequestStatus()) {
@@ -179,7 +180,7 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
                             purchase.setItemType(IabHelper.ITEM_TYPE_INAPP);
                             purchase.setSku(OpenIabHelper.getSku(OpenIabHelper.NAME_AMAZON, storeSku));
                             inventory.addPurchase(purchase);
-                            Log.d(TAG, "Add to inventory SKU: " + storeSku);
+                            if (mDebugLog) Log.d(TAG, "Add to inventory SKU: " + storeSku);
                             break;
                         case SUBSCRIPTION:
                             final SubscriptionPeriod subscriptionPeriod = receipt.getSubscriptionPeriod();
@@ -188,7 +189,7 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
                                 purchase.setItemType(IabHelper.ITEM_TYPE_SUBS);
                                 purchase.setSku(OpenIabHelper.getSku(OpenIabHelper.NAME_AMAZON, storeSku));
                                 inventory.addPurchase(purchase);
-                                Log.d(TAG, "Add subscription to inventory SKU: " + storeSku);
+                                if (mDebugLog) Log.d(TAG, "Add subscription to inventory SKU: " + storeSku);
                             }
                             
 //                            final Date startDate = subscriptionPeriod.getStartDate();
@@ -222,7 +223,7 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
 
                 final Offset newOffset = purchaseUpdatesResponse.getOffset();
                 if (purchaseUpdatesResponse.isMore()) {
-                    Log.v(TAG, "Initiating Another Purchase Updates with offset: " + newOffset.toString());
+                    if (mDebugLog) Log.v(TAG, "Initiating Another Purchase Updates with offset: " + newOffset.toString());
                     PurchasingManager.initiatePurchaseUpdatesRequest(newOffset);
                 } else {
                     inventoryLatch.countDown();
@@ -238,12 +239,12 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
 
     @Override
     public void onItemDataResponse(final ItemDataResponse itemDataResponse) {
-        Log.v(TAG, "onItemDataResponse() reqStatus: " + itemDataResponse.getItemDataRequestStatus()+ ", reqId: " + itemDataResponse.getRequestId());
+        if (mDebugLog) Log.v(TAG, "onItemDataResponse() reqStatus: " + itemDataResponse.getItemDataRequestStatus()+ ", reqId: " + itemDataResponse.getRequestId());
         switch (itemDataResponse.getItemDataRequestStatus()) {
             case SUCCESSFUL_WITH_UNAVAILABLE_SKUS:
                 // Skus that you can not purchase will be here.
                 for (final String s : itemDataResponse.getUnavailableSkus()) {
-                    Log.v(TAG, "Unavailable SKU:" + s);
+                    if (mDebugLog) Log.v(TAG, "Unavailable SKU:" + s);
                 }
             case SUCCESSFUL:
                 // Information you'll want to display about your IAP items is here
@@ -252,7 +253,7 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
                 for (final String key : items.keySet()) {
                     Item i = items.get(key);
                     final String storeSku = i.getSku();
-                    Log.v(TAG, String.format("Item: %s\n Type: %s\n SKU: %s\n Price: %s\n Description: %s\n", i.getTitle(), i.getItemType(), storeSku, i.getPrice(), i.getDescription()));
+                    if (mDebugLog) Log.v(TAG, String.format("Item: %s\n Type: %s\n SKU: %s\n Price: %s\n Description: %s\n", i.getTitle(), i.getItemType(), storeSku, i.getPrice(), i.getDescription()));
                     String itemType = i.getItemType() == Item.ItemType.SUBSCRIPTION ? IabHelper.ITEM_TYPE_SUBS : IabHelper.ITEM_TYPE_INAPP;
                     String sku = OpenIabHelper.getSku(OpenIabHelper.NAME_AMAZON, storeSku);
                     SkuDetails skuDetails = new SkuDetails(itemType, sku, i.getTitle(), i.getPrice(), i.getDescription());
@@ -274,13 +275,13 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
 
     @Override
     public void onPurchaseResponse(final PurchaseResponse purchaseResponse) {
-        Log.v(TAG, "onPurchaseResponse() PurchaseRequestStatus:" + purchaseResponse.getPurchaseRequestStatus());
+        if (mDebugLog) Log.v(TAG, "onPurchaseResponse() PurchaseRequestStatus:" + purchaseResponse.getPurchaseRequestStatus());
 
         IabResult result = null;
         Purchase purchase = new Purchase(OpenIabHelper.NAME_AMAZON);
         
         if (!purchaseResponse.getUserId().equals(currentUserId)) {
-            Log.w(TAG, "onPurchaseResponse() userId: " + currentUserId + ", purchase.userId: " + purchaseResponse.getUserId());
+            if (mDebugLog) Log.w(TAG, "onPurchaseResponse() userId: " + currentUserId + ", purchase.userId: " + purchaseResponse.getUserId());
             result = new IabResult(IabHelper.BILLING_RESPONSE_RESULT_ERROR, "userId doesn't match purchase.userId");
         } else {
             switch (purchaseResponse.getPurchaseRequestStatus()) {
@@ -315,7 +316,7 @@ public class AmazonAppstoreBillingService extends BasePurchasingObserver impleme
         if (listener != null) {
             listener.onIabPurchaseFinished(result, purchase);
         } else {
-            Log.e(TAG, "Something went wrong: PurchaseFinishedListener is null");
+            if (mDebugLog) Log.e(TAG, "Something went wrong: PurchaseFinishedListener is null");
         }
     }
     

--- a/library/src/org/onepf/oms/appstore/GooglePlay.java
+++ b/library/src/org/onepf/oms/appstore/GooglePlay.java
@@ -35,6 +35,7 @@ import android.util.Log;
  */
 
 public class GooglePlay extends DefaultAppstore {
+    private static final boolean mDebugLog = false;
     private static final String TAG = GooglePlay.class.getSimpleName();
 
     public  static final String ANDROID_INSTALLER = "com.android.vending";
@@ -70,12 +71,12 @@ public class GooglePlay extends DefaultAppstore {
      */
     @Override    
     public boolean isBillingAvailable(String packageName) {
-        Log.d(TAG, "isBillingAvailable() packageName: " + packageName);
+        if (mDebugLog) Log.d(TAG, "isBillingAvailable() packageName: " + packageName);
         PackageManager packageManager = mContext.getPackageManager();
         List<PackageInfo> allPackages = packageManager.getInstalledPackages(0);
         for (PackageInfo packageInfo : allPackages) {
             if (packageInfo.packageName.equals(GOOGLE_INSTALLER) || packageInfo.packageName.equals(ANDROID_INSTALLER)) {
-                Log.d(TAG, "Google supports billing");
+                if (mDebugLog) Log.d(TAG, "Google supports billing");
                 return true;
             }
         }

--- a/library/src/org/onepf/oms/appstore/OpenAppstore.java
+++ b/library/src/org/onepf/oms/appstore/OpenAppstore.java
@@ -38,6 +38,7 @@ import com.android.vending.billing.IInAppBillingService;
  * @since 28.05.13
  */
 public class OpenAppstore extends DefaultAppstore {
+    private static final boolean mDebugLog = false;
     private static final String TAG = OpenAppstore.class.getSimpleName();
     
     private Context context;
@@ -66,7 +67,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.isPackageInstaller(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return false;
         }
     }
@@ -76,7 +77,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.isBillingAvailable(packageName);
         } catch (RemoteException e) {
-            Log.e(TAG, "isBillingAvailable() packageName: " + packageName, e);
+            if (mDebugLog) Log.e(TAG, "isBillingAvailable() packageName: " + packageName, e);
             return false;
         }
     }
@@ -86,7 +87,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getPackageVersion(packageName);
         } catch (RemoteException e) {
-            Log.e(TAG, "getPackageVersion() packageName: " + packageName, e);
+            if (mDebugLog) Log.e(TAG, "getPackageVersion() packageName: " + packageName, e);
             return Appstore.PACKAGE_VERSION_UNDEFINED;
         }
     }
@@ -96,7 +97,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getAppstoreName();
         } catch (RemoteException e) {
-            Log.e(TAG, "getAppstoreName() AppstoreName is unavailable", e);
+            if (mDebugLog) Log.e(TAG, "getAppstoreName() AppstoreName is unavailable", e);
             return null;
         }
     }
@@ -106,7 +107,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getProductPageIntent(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return null;
         }
     }
@@ -116,7 +117,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getRateItPageIntent(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return null;
         }
     }
@@ -126,7 +127,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getSameDeveloperPageIntent(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return null;
         }
     }
@@ -136,7 +137,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.areOutsideLinksAllowed();
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return false;
         }
     }

--- a/library/src/org/onepf/oms/appstore/SamsungAppsBillingService.java
+++ b/library/src/org/onepf/oms/appstore/SamsungAppsBillingService.java
@@ -53,6 +53,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
     private static final int ITEM_RESPONSE_COUNT = 100;
     private final int CURRENT_MODE = SamsungApps.isDebugMode ? IAP_MODE_TEST_SUCCESS : IAP_MODE_COMMERCIAL;
 
+    private static final boolean mDebugLog = false;
     private static final String TAG = SamsungAppsBillingService.class.getSimpleName();
 
     private static final int HONEYCOMB_MR1 = 12;
@@ -177,10 +178,10 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
             do {
                 itemInbox = null;
                 try {
-                    Log.d(TAG, "getItemsInbox, startNum = " + startNum + ", endNum = " + endNum);
+                    if (mDebugLog) Log.d(TAG, "getItemsInbox, startNum = " + startNum + ", endNum = " + endNum);
                     itemInbox = mIapConnector.getItemsInbox(mContext.getPackageName(), itemGroupId, startNum, endNum, "19700101", today);
                 } catch (RemoteException e) {
-                    Log.e(TAG, "Samsung getItemsInbox: " + e.getMessage());
+                    if (mDebugLog) Log.e(TAG, "Samsung getItemsInbox: " + e.getMessage());
                 }
                 startNum += ITEM_RESPONSE_COUNT;
                 endNum += ITEM_RESPONSE_COUNT;
@@ -211,7 +212,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
                         try {
                             itemList = mIapConnector.getItemList(CURRENT_MODE, mContext.getPackageName(), itemGroupId, startNum, endNum, ITEM_TYPE_ALL);
                         } catch (RemoteException e) {
-                            Log.e(TAG, "Samsung getItemList: " + e.getMessage());
+                            if (mDebugLog) Log.e(TAG, "Samsung getItemList: " + e.getMessage());
                         }
                         startNum += ITEM_RESPONSE_COUNT;
                         endNum += ITEM_RESPONSE_COUNT;
@@ -231,7 +232,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
         bundle.putString(KEY_NAME_THIRD_PARTY_NAME, activity.getPackageName());
         bundle.putString(KEY_NAME_ITEM_GROUP_ID, itemGroupId);
         bundle.putString(KEY_NAME_ITEM_ID, itemId);
-        Log.d(TAG, "launchPurchase: itemGroupId = " + itemGroupId + ", itemId = " + itemId);
+        if (mDebugLog) Log.d(TAG, "launchPurchase: itemGroupId = " + itemGroupId + ", itemId = " + itemId);
         ComponentName cmpName = new ComponentName(SamsungApps.IAP_PACKAGE_NAME, PAYMENT_ACTIVITY_NAME);
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_LAUNCHER);
@@ -242,7 +243,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
         mPurchasingItemType = itemType;
         mItemGroupId = itemGroupId;
         mExtraData = extraData;
-        Log.d(TAG, "Request code: " + requestCode);
+        if (mDebugLog) Log.d(TAG, "Request code: " + requestCode);
         activity.startActivityForResult(intent, requestCode);
     }
 
@@ -298,7 +299,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
                     purchase.setPurchaseTime(Long.parseLong(purchaseJson.getString(JSON_KEY_PURCHASE_DATE)));
                     purchase.setToken(purchaseJson.getString(JSON_KEY_PURCHASE_ID));
                 } catch (JSONException e) {
-                    Log.e(TAG, "JSON parse error: " + e.getMessage());
+                    if (mDebugLog) Log.e(TAG, "JSON parse error: " + e.getMessage());
                 }
 
                 purchase.setItemType(mPurchasingItemType);
@@ -308,7 +309,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
                 purchase.setDeveloperPayload(mExtraData);
             }
         }
-        Log.d(TAG, "Samsung result code: " + errorCode + ", msg: " + errorMsg);
+        if (mDebugLog) Log.d(TAG, "Samsung result code: " + errorCode + ", msg: " + errorMsg);
         mPurchaseListener.onIabPurchaseFinished(new IabResult(errorCode, errorMsg), purchase);
         return true;
     }
@@ -374,14 +375,14 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
             Bundle result = mIapConnector.init(CURRENT_MODE);
             if (result != null) {
                 int statusCode = result.getInt(KEY_NAME_STATUS_CODE);
-                Log.d(TAG, "Init IAP connection status code: " + statusCode);
+                if (mDebugLog) Log.d(TAG, "Init IAP connection status code: " + statusCode);
                 errorMsg = result.getString(KEY_NAME_ERROR_STRING);
                 if (statusCode == IAP_ERROR_NONE) {
                     errorCode = IabHelper.BILLING_RESPONSE_RESULT_OK;
                 }
             }
         } catch (RemoteException e) {
-            Log.d(TAG, "Init IAP: " + e.getMessage());
+            if (mDebugLog) Log.d(TAG, "Init IAP: " + e.getMessage());
         }
         mSetupListener.onIabSetupFinished(new IabResult(errorCode, errorMsg));
     }
@@ -426,7 +427,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
                     }
                 }
             } catch (JSONException e) {
-                Log.e(TAG, "JSON parse error: " + e.getMessage());
+                if (mDebugLog) Log.e(TAG, "JSON parse error: " + e.getMessage());
             }
         }
         return items.size() == ITEM_RESPONSE_COUNT;

--- a/library/src/org/onepf/oms/appstore/TStoreBillingService.java
+++ b/library/src/org/onepf/oms/appstore/TStoreBillingService.java
@@ -33,6 +33,7 @@ import java.util.List;
  * Date: 16.05.13
  */
 public class TStoreBillingService implements AppstoreInAppBillingService {
+    private static final boolean mDebugLog = false;
     private static final String TAG = "IabHelper";
     private final Context mContext;
     private final String mAppId;
@@ -56,11 +57,11 @@ public class TStoreBillingService implements AppstoreInAppBillingService {
         paramsBuilder.put(ParamsBuilder.KEY_PID, sku);
         Bundle req = mPlugin.sendPaymentRequest(paramsBuilder.build(), new TStoreRequestCallback(this, mContext, listener));
         if (req == null) {
-            Log.e(TAG, "TStore buy request failure");
+            if (mDebugLog) Log.e(TAG, "TStore buy request failure");
         } else {
             String mRequestId = req.getString(IapPlugin.EXTRA_REQUEST_ID);
             if (mRequestId == null || mRequestId.length() == 0) {
-                Log.e(TAG, "TStore request failure");
+                if (mDebugLog) Log.e(TAG, "TStore request failure");
             }
         }
     }

--- a/library/src/org/onepf/oms/appstore/TStoreRequestCallback.java
+++ b/library/src/org/onepf/oms/appstore/TStoreRequestCallback.java
@@ -35,6 +35,7 @@ import org.onepf.oms.appstore.tstoreUtils.Response;
  * Date: 05.04.13
  */
 public class TStoreRequestCallback implements IapPlugin.RequestCallback {
+    private static final boolean mDebugLog = false;
     private static final String TAG = "IabHelper";
 
     private final Context mContext;
@@ -50,7 +51,7 @@ public class TStoreRequestCallback implements IapPlugin.RequestCallback {
 
     @Override
     public void onError(String reqid, String errcode, String errmsg) {
-        Log.e(TAG, "TStore error. onError() identifier:" + reqid + " code:" + errcode + " msg:" + errmsg);
+        if (mDebugLog) Log.e(TAG, "TStore error. onError() identifier:" + reqid + " code:" + errcode + " msg:" + errmsg);
         // TODO: support different error codes
         IabResult result = new IabResult(IabHelper.BILLING_RESPONSE_RESULT_ERROR, errmsg);
     }
@@ -58,7 +59,7 @@ public class TStoreRequestCallback implements IapPlugin.RequestCallback {
     @Override
     public void onResponse(IapResponse data) {
         if (data == null || data.getContentLength() <= 0) {
-            Log.e(TAG, "onResponse() response data is null");
+            if (mDebugLog) Log.e(TAG, "onResponse() response data is null");
             return;
         }
         Response response = new GsonConverter().fromJson(data.getContentToString());

--- a/library/src/org/onepf/oms/appstore/googleUtils/IabHelper.java
+++ b/library/src/org/onepf/oms/appstore/googleUtils/IabHelper.java
@@ -83,7 +83,7 @@ public class IabHelper implements AppstoreInAppBillingService {
     public static final int QUERY_SKU_DETAILS_BATCH_SIZE = 20;
     
     // Is debug logging enabled?
-    boolean mDebugLog = true;
+    boolean mDebugLog = false;
     String mDebugTag = TAG;
 
     // Is setup done?
@@ -262,7 +262,7 @@ public class IabHelper implements AppstoreInAppBillingService {
                         listener.onIabSetupFinished(new IabResult(IABHELPER_REMOTE_EXCEPTION,
                                                     "RemoteException while setting up in-app billing."));
                     }
-                    Log.e(TAG, "RemoteException while setting up in-app billing", e);
+                    if (mDebugLog) Log.e(TAG, "RemoteException while setting up in-app billing", e);
                     return;
                 }
 
@@ -1014,11 +1014,11 @@ public class IabHelper implements AppstoreInAppBillingService {
     }
 
     void logError(String msg) {
-        Log.e(mDebugTag, "In-app billing error: " + msg);
+        if (mDebugLog) Log.e(mDebugTag, "In-app billing error: " + msg);
     }
 
     void logWarn(String msg) {
-        Log.w(mDebugTag, "In-app billing warning: " + msg);
+        if (mDebugLog) Log.w(mDebugTag, "In-app billing warning: " + msg);
     }
 
     boolean isValidDataSignature(String base64PublicKey, String purchaseData, String signature) {

--- a/library/src/org/onepf/oms/appstore/googleUtils/Security.java
+++ b/library/src/org/onepf/oms/appstore/googleUtils/Security.java
@@ -37,6 +37,7 @@ import android.util.Log;
  * purchases as verified.
  */
 public class Security {
+    private static final boolean mDebugLog = false;
     private static final String TAG = "IABUtil/Security";
 
     private static final String KEY_FACTORY_ALGORITHM = "RSA";
@@ -54,7 +55,7 @@ public class Security {
     public static boolean verifyPurchase(String base64PublicKey, String signedData, String signature) {
         if (TextUtils.isEmpty(signedData) || TextUtils.isEmpty(base64PublicKey) 
                 || TextUtils.isEmpty(signature)) {
-            Log.e(TAG, "Purchase verification failed: missing data.");
+            if (mDebugLog) Log.e(TAG, "Purchase verification failed: missing data.");
             return false;
         }
         
@@ -77,10 +78,10 @@ public class Security {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         } catch (InvalidKeySpecException e) {
-            Log.e(TAG, "Invalid key specification.");
+            if (mDebugLog) Log.e(TAG, "Invalid key specification.");
             throw new IllegalArgumentException(e);
         } catch (Base64DecoderException e) {
-            Log.e(TAG, "Base64 decoding failed.");
+            if (mDebugLog) Log.e(TAG, "Base64 decoding failed.");
             throw new IllegalArgumentException(e);
         }
     }
@@ -101,18 +102,18 @@ public class Security {
             sig.initVerify(publicKey);
             sig.update(signedData.getBytes());
             if (!sig.verify(Base64.decode(signature))) {
-                Log.e(TAG, "Signature verification failed.");
+                if (mDebugLog) Log.e(TAG, "Signature verification failed.");
                 return false;
             }
             return true;
         } catch (NoSuchAlgorithmException e) {
-            Log.e(TAG, "NoSuchAlgorithmException.");
+            if (mDebugLog) Log.e(TAG, "NoSuchAlgorithmException.");
         } catch (InvalidKeyException e) {
-            Log.e(TAG, "Invalid key specification.");
+            if (mDebugLog) Log.e(TAG, "Invalid key specification.");
         } catch (SignatureException e) {
-            Log.e(TAG, "Signature exception.");
+            if (mDebugLog) Log.e(TAG, "Signature exception.");
         } catch (Base64DecoderException e) {
-            Log.e(TAG, "Base64 decoding failed.");
+            if (mDebugLog) Log.e(TAG, "Base64 decoding failed.");
         }
         return false;
     }


### PR DESCRIPTION
Application shouldn't write anything to logcat in release mode. Logcat should only contain
information valuable for a wide range of people using it (like system errors, etc.). Hiding
debug output in production release is a requirement for many projects which may want to
use openiab.
