### PR TITLE
Hide library output into logcat.

### DIFF
--- a/library/src/org/onepf/oms/OpenIabHelper.java
+++ b/library/src/org/onepf/oms/OpenIabHelper.java
@@ -170,7 +170,7 @@ public class OpenIabHelper {
             Map<String, String> skuMap = sku2storeSkuMappings.get(appstoreName);
             if (skuMap != null && skuMap.get(sku) != null) {
                 currentStoreSku = skuMap.get(sku);
-                Log.d(TAG, "getStoreSku() using mapping for sku: " + sku + " -> " + currentStoreSku);
+                if (mDebugLog) Log.d(TAG, "getStoreSku() using mapping for sku: " + sku + " -> " + currentStoreSku);
             }
             return currentStoreSku;
         }
@@ -182,7 +182,7 @@ public class OpenIabHelper {
             Map<String, String> skuMap = storeSku2skuMappings.get(appstoreName);
             if (skuMap != null && skuMap.get(sku) != null) {
                 sku = skuMap.get(sku);
-                Log.d(TAG, "getSku() restore sku from storeSku: " + storeSku + " -> " + sku);
+                if (mDebugLog) Log.d(TAG, "getSku() restore sku from storeSku: " + storeSku + " -> " + sku);
             }
             return sku;
         }
@@ -251,7 +251,7 @@ public class OpenIabHelper {
                     stores2check.addAll(options.availableStores);
                 } else { // if appstores are not specified by user - lookup for all available stores
                     final List<Appstore> openStores = discoverOpenStores(context, null, options);
-                    Log.d(TAG, "startSetup() discovered openstores: " + openStores.toString());
+                    if (mDebugLog) Log.d(TAG, "startSetup() discovered openstores: " + openStores.toString());
                     stores2check.addAll(openStores);
                     if (options.verifyMode == Options.VERIFY_EVERYTHING && !options.storeKeys.containsKey(NAME_GOOGLE)) {
                         // don't work with GooglePlay if verifyMode is strict and no publicKey provided 
@@ -270,23 +270,23 @@ public class OpenIabHelper {
                 }
                 
                 if (options.checkInventory) {
-                    Log.d(TAG, "startSetup() check inventory. stores: " + stores2check);
+                    if (mDebugLog) Log.d(TAG, "startSetup() check inventory. stores: " + stores2check);
                     final List<Appstore> equippedStores = inventoryCheck(stores2check);
-                    Log.d(TAG, "startSetup() equipped stores: " + equippedStores);
+                    if (mDebugLog) Log.d(TAG, "startSetup() equipped stores: " + equippedStores);
                     if (equippedStores.size() > 0) {
                         mAppstore = selectBillingService(equippedStores);
-                        Log.d(TAG, "startSetup() selected store: " + mAppstore);
+                        if (mDebugLog) Log.d(TAG, "startSetup() selected store: " + mAppstore);
                     } 
                     if (mAppstore != null) {
                         mAppstoreBillingService = mAppstore.getInAppBillingService();
                         final IabResult result = new IabResult(BILLING_RESPONSE_RESULT_OK
                                 , "Successfully initialized with existing inventory: " + mAppstore.getAppstoreName());
                         fireSetupFinished(listener, result);
-                        Log.d(TAG, "startSetup() selected store: " + mAppstore);
+                        if (mDebugLog) Log.d(TAG, "startSetup() selected store: " + mAppstore);
                         return;
                     } 
                     // found no equipped stores. Select store based on store parameters
-                    Log.d(TAG, "startSetup() equipped elections: " + mAppstore);
+                    if (mDebugLog) Log.d(TAG, "startSetup() equipped elections: " + mAppstore);
                     IabResult result = new IabResult(BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE, "Billing isn't supported");
                     if (mAppstore == null) {
                         mAppstore = selectBillingService(stores2check);
@@ -295,17 +295,17 @@ public class OpenIabHelper {
                         mAppstoreBillingService = mAppstore.getInAppBillingService();
                         result = new IabResult(BILLING_RESPONSE_RESULT_OK
                                 , "Successfully initialized: " + mAppstore.getAppstoreName());
-                        Log.d(TAG, "startSetup() selected store: " + mAppstore);
+                        if (mDebugLog) Log.d(TAG, "startSetup() selected store: " + mAppstore);
                     } else {
                         result = new IabResult(BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE
                                 , "Billing isn't supported");
-                        Log.d(TAG, "startSetup() billing is not available");
+                        if (mDebugLog) Log.d(TAG, "startSetup() billing is not available");
                     }
                     fireSetupFinished(listener, result);
                 } else {                // no inventory check. Select store based on store parameters   
-                    Log.d(TAG, "startSetup() No inventory check. stores: " + stores2check);
+                    if (mDebugLog) Log.d(TAG, "startSetup() No inventory check. stores: " + stores2check);
                     mAppstore = selectBillingService(stores2check);
-                    Log.d(TAG, "startSetup() selected store: " + mAppstore);
+                    if (mDebugLog) Log.d(TAG, "startSetup() selected store: " + mAppstore);
                     if (mAppstore == null) {
                         IabResult iabResult = new IabResult(BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE, "Billing isn't supported");
                         fireSetupFinished(listener, iabResult);
@@ -369,7 +369,7 @@ public class OpenIabHelper {
             context.bindService(intentAppstore, new ServiceConnection() {
                 @Override
                 public void onServiceConnected(ComponentName name, IBinder service) {
-                    Log.d(TAG, "discoverOpenStores() appstoresService connected for component: " + name.flattenToShortString());
+                    if (mDebugLog) Log.d(TAG, "discoverOpenStores() appstoresService connected for component: " + name.flattenToShortString());
                     IOpenAppstore openAppstoreService = IOpenAppstore.Stub.asInterface(service);
 
                     try {
@@ -378,7 +378,7 @@ public class OpenIabHelper {
                         if (appstoreName == null) { // no name - no service
                             Log.e(TAG, "discoverOpenStores() Appstore doesn't have name. Skipped. ComponentName: " + name);
                         } else if (billingIntent == null) { // don't handle stores without billing support
-                            Log.d(TAG, "discoverOpenStores(): billing is not supported by store: " + name);
+                            if (mDebugLog) Log.d(TAG, "discoverOpenStores(): billing is not supported by store: " + name);
                         } else if ((options.verifyMode == Options.VERIFY_EVERYTHING) && !options.storeKeys.containsKey(appstoreName)) { 
                             // don't connect to OpenStore if no key provided and verification is strict
                             Log.e(TAG, "discoverOpenStores(): verification is required but publicKey is not provided: " + name);
@@ -402,7 +402,7 @@ public class OpenIabHelper {
 
                 @Override
                 public void onServiceDisconnected(ComponentName name) {
-                    Log.d(TAG, "onServiceDisconnected() appstoresService disconnected for component: " + name.flattenToShortString());
+                    if (mDebugLog) Log.d(TAG, "onServiceDisconnected() appstoresService disconnected for component: " + name.flattenToShortString());
                     //Nothing to do here
                 }
             }, Context.BIND_AUTO_CREATE);
@@ -447,7 +447,7 @@ public class OpenIabHelper {
                                 if (inventory.getAllPurchases().size() > 0) {
                                     equippedStores.add(appstore);
                                 }
-                                Log.d(TAG, "inventoryCheck() found: " + inventory.getAllPurchases().size() + " purchases in " + appstore.getAppstoreName());
+                                if (mDebugLog) Log.d(TAG, "inventoryCheck() found: " + inventory.getAllPurchases().size() + " purchases in " + appstore.getAppstoreName());
                             } catch (IabException e) {
                                 Log.e(TAG, "inventoryCheck() failed for " + appstore.getAppstoreName());
                             }
@@ -736,7 +736,7 @@ public class OpenIabHelper {
     }
 
     void logWarn(String msg) {
-        Log.w(TAG, "In-app billing warning: " + msg);
+        if (mDebugLog) Log.w(TAG, "In-app billing warning: " + msg);
     }
     
     public interface OnInitListener {

--- a/library/src/org/onepf/oms/appstore/AmazonAppstore.java
+++ b/library/src/org/onepf/oms/appstore/AmazonAppstore.java
@@ -29,6 +29,7 @@ import android.util.Log;
  * Date: 16.04.13
  */
 public class AmazonAppstore extends DefaultAppstore {
+    private static final boolean mDebugLog = false;
     private static final String TAG = AmazonAppstore.class.getSimpleName();
     
     private volatile Boolean sandboxMode;// = false;
@@ -43,7 +44,7 @@ public class AmazonAppstore extends DefaultAppstore {
 
     @Override
     public boolean isPackageInstaller(String packageName) {
-        Log.d(TAG, "isPackageInstaller() packageName: " + packageName);
+        if (mDebugLog) Log.d(TAG, "isPackageInstaller() packageName: " + packageName);
         if (sandboxMode != null) {
             return !sandboxMode;
         }
@@ -53,11 +54,11 @@ public class AmazonAppstore extends DefaultAppstore {
                 localClassLoader.loadClass("com.amazon.android.Kiwi");
                 sandboxMode = false;
             } catch (Throwable localThrowable) {
-                Log.d(TAG, "isPackageInstaller() cannot load class com.amazon.android.Kiwi ");
+                if (mDebugLog) Log.d(TAG, "isPackageInstaller() cannot load class com.amazon.android.Kiwi ");
                 sandboxMode = true;
             }
         }
-        Log.d(TAG, "isPackageInstaller() sandBox: " + sandboxMode);
+        if (mDebugLog) Log.d(TAG, "isPackageInstaller() sandBox: " + sandboxMode);
         return !sandboxMode;
     }
 

--- a/library/src/org/onepf/oms/appstore/GooglePlay.java
+++ b/library/src/org/onepf/oms/appstore/GooglePlay.java
@@ -35,6 +35,7 @@ import android.util.Log;
  */
 
 public class GooglePlay extends DefaultAppstore {
+    private static final boolean mDebugLog = false;
     private static final String TAG = GooglePlay.class.getSimpleName();
 
     public  static final String ANDROID_INSTALLER = "com.android.vending";
@@ -70,12 +71,12 @@ public class GooglePlay extends DefaultAppstore {
      */
     @Override    
     public boolean isBillingAvailable(String packageName) {
-        Log.d(TAG, "isBillingAvailable() packageName: " + packageName);
+        if (mDebugLog) Log.d(TAG, "isBillingAvailable() packageName: " + packageName);
         PackageManager packageManager = mContext.getPackageManager();
         List<PackageInfo> allPackages = packageManager.getInstalledPackages(0);
         for (PackageInfo packageInfo : allPackages) {
             if (packageInfo.packageName.equals(GOOGLE_INSTALLER) || packageInfo.packageName.equals(ANDROID_INSTALLER)) {
-                Log.d(TAG, "Google supports billing");
+                if (mDebugLog) Log.d(TAG, "Google supports billing");
                 return true;
             }
         }

--- a/library/src/org/onepf/oms/appstore/OpenAppstore.java
+++ b/library/src/org/onepf/oms/appstore/OpenAppstore.java
@@ -39,6 +39,7 @@ import com.android.vending.billing.IInAppBillingService;
  * @since 28.05.13
  */
 public class OpenAppstore extends DefaultAppstore {
+    private static final boolean mDebugLog = false;
     private static final String TAG = OpenAppstore.class.getSimpleName();
     
     private Context context;
@@ -78,7 +79,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.isPackageInstaller(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return false;
         }
     }
@@ -113,7 +114,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getProductPageIntent(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return null;
         }
     }
@@ -123,7 +124,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getRateItPageIntent(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return null;
         }
     }
@@ -133,7 +134,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.getSameDeveloperPageIntent(packageName);
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return null;
         }
     }
@@ -143,7 +144,7 @@ public class OpenAppstore extends DefaultAppstore {
         try {
             return openAppstoreService.areOutsideLinksAllowed();
         } catch (RemoteException e) {
-            Log.w(TAG, "RemoteException: " + e.getMessage());
+            if (mDebugLog) Log.w(TAG, "RemoteException: " + e.getMessage());
             return false;
         }
     }

--- a/library/src/org/onepf/oms/appstore/SamsungAppsBillingService.java
+++ b/library/src/org/onepf/oms/appstore/SamsungAppsBillingService.java
@@ -53,6 +53,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
     private static final int ITEM_RESPONSE_COUNT = 100;
     private final int CURRENT_MODE = SamsungApps.isDebugMode ? IAP_MODE_TEST_SUCCESS : IAP_MODE_COMMERCIAL;
 
+    private static final boolean mDebugLog = false;
     private static final String TAG = SamsungAppsBillingService.class.getSimpleName();
 
     private static final int HONEYCOMB_MR1 = 12;
@@ -177,7 +178,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
             do {
                 itemInbox = null;
                 try {
-                    Log.d(TAG, "getItemsInbox, startNum = " + startNum + ", endNum = " + endNum);
+                    if (mDebugLog) Log.d(TAG, "getItemsInbox, startNum = " + startNum + ", endNum = " + endNum);
                     itemInbox = mIapConnector.getItemsInbox(mContext.getPackageName(), itemGroupId, startNum, endNum, "19700101", today);
                 } catch (RemoteException e) {
                     Log.e(TAG, "Samsung getItemsInbox: " + e.getMessage());
@@ -231,7 +232,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
         bundle.putString(KEY_NAME_THIRD_PARTY_NAME, activity.getPackageName());
         bundle.putString(KEY_NAME_ITEM_GROUP_ID, itemGroupId);
         bundle.putString(KEY_NAME_ITEM_ID, itemId);
-        Log.d(TAG, "launchPurchase: itemGroupId = " + itemGroupId + ", itemId = " + itemId);
+        if (mDebugLog) Log.d(TAG, "launchPurchase: itemGroupId = " + itemGroupId + ", itemId = " + itemId);
         ComponentName cmpName = new ComponentName(SamsungApps.IAP_PACKAGE_NAME, PAYMENT_ACTIVITY_NAME);
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_LAUNCHER);
@@ -242,7 +243,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
         mPurchasingItemType = itemType;
         mItemGroupId = itemGroupId;
         mExtraData = extraData;
-        Log.d(TAG, "Request code: " + requestCode);
+        if (mDebugLog) Log.d(TAG, "Request code: " + requestCode);
         activity.startActivityForResult(intent, requestCode);
     }
 
@@ -308,7 +309,7 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
                 purchase.setDeveloperPayload(mExtraData);
             }
         }
-        Log.d(TAG, "Samsung result code: " + errorCode + ", msg: " + errorMsg);
+        if (mDebugLog) Log.d(TAG, "Samsung result code: " + errorCode + ", msg: " + errorMsg);
         mPurchaseListener.onIabPurchaseFinished(new IabResult(errorCode, errorMsg), purchase);
         return true;
     }
@@ -374,14 +375,14 @@ public class SamsungAppsBillingService implements AppstoreInAppBillingService {
             Bundle result = mIapConnector.init(CURRENT_MODE);
             if (result != null) {
                 int statusCode = result.getInt(KEY_NAME_STATUS_CODE);
-                Log.d(TAG, "Init IAP connection status code: " + statusCode);
+                if (mDebugLog) Log.d(TAG, "Init IAP connection status code: " + statusCode);
                 errorMsg = result.getString(KEY_NAME_ERROR_STRING);
                 if (statusCode == IAP_ERROR_NONE) {
                     errorCode = IabHelper.BILLING_RESPONSE_RESULT_OK;
                 }
             }
         } catch (RemoteException e) {
-            Log.d(TAG, "Init IAP: " + e.getMessage());
+            if (mDebugLog) Log.d(TAG, "Init IAP: " + e.getMessage());
         }
         mSetupListener.onIabSetupFinished(new IabResult(errorCode, errorMsg));
     }

--- a/library/src/org/onepf/oms/appstore/googleUtils/IabHelper.java
+++ b/library/src/org/onepf/oms/appstore/googleUtils/IabHelper.java
@@ -83,7 +83,7 @@ public class IabHelper implements AppstoreInAppBillingService {
     public static final int QUERY_SKU_DETAILS_BATCH_SIZE = 20;
     
     // Is debug logging enabled?
-    boolean mDebugLog = true;
+    boolean mDebugLog = false;
     String mDebugTag = TAG;
 
     // Is setup done?
@@ -1021,7 +1021,7 @@ public class IabHelper implements AppstoreInAppBillingService {
     }
 
     void logWarn(String msg) {
-        Log.w(mDebugTag, "In-app billing warning: " + msg);
+        if (mDebugLog) Log.w(mDebugTag, "In-app billing warning: " + msg);
     }
 
     boolean isValidDataSignature(String base64PublicKey, String purchaseData, String signature) {


### PR DESCRIPTION
Application shouldn't write anything to logcat in release mode. Logcat should only contain
information valuable for a wide range of people using it (like system errors, etc.). Hiding
debug output in production release is a requirement for many projects which may want to
use openiab.
