### PR TITLE
fix hang if no store available

### DIFF
--- a/library/src/org/onepf/oms/OpenIabHelper.java
+++ b/library/src/org/onepf/oms/OpenIabHelper.java
@@ -416,6 +416,8 @@ public class OpenIabHelper {
                                 fireSetupFinished(listener, result);
                             }
                         });
+                    } else {
+                        fireSetupFinished(listener, result);
                     }
                 }
                 for (Appstore store : stores2check) {


### PR DESCRIPTION
in some cases when no app store available onIabSetupFinished() will never invoked.
this patch fixes it.
