### PR TITLE
Fix proguard for Options.Builder.

### DIFF
--- a/library/proguard-unity.txt
+++ b/library/proguard-unity.txt
@@ -26,6 +26,12 @@
     public *** launchSubscriptionPurchaseFlow(...);
 }
 
+-keep class org.onepf.oms.OpenIabHelper$Options$Builder {
+    public *** setVerifyMode(...);
+    public *** addStoreKeys(...);
+    public org.onepf.oms.OpenIabHelper.Options build();
+}
+
 -keep class org.onepf.oms.OpenIabHelper {
     public static final *** !NAME_FORTUMO;
 }


### PR DESCRIPTION
Fix build Unity plugin without Fortumo using Options.Builder.
