### PR TITLE
Add check for STATE_DISPOSED in finishSetup()

### DIFF
--- a/library/src/main/java/org/onepf/oms/OpenIabHelper.java
+++ b/library/src/main/java/org/onepf/oms/OpenIabHelper.java
@@ -757,7 +757,7 @@ public class OpenIabHelper {
                              @NotNull final IabResult iabResult,
                              @Nullable final Appstore appstore) {
         if (setupState == SETUP_DISPOSED) {
-            Logger.e("finishSetup() called for disposed OpenIabHelper, returning.");
+            Logger.w("finishSetup() called for disposed OpenIabHelper, returning.");
             return;
         }                             
         if (!Utils.uiThread()) {


### PR DESCRIPTION
In our application, we use `OpenIabHelper.startSetup()` in our `onCreate()` method and `OpenIabHelper.dispose()` in our `onDestroy()` method.

If the activity is recreated (e.g. by the system as a result of a screen orientation change), then `dispose()` is called, and we setup a new OpenIabHelper. The asynchronous setup ignores this state change (to `STATE_DISPOSED`), and will throw `IllegalStateException` when the setup is finished.

At this point, we don't care about _that_ OpenIabHelper finishing the setup, we only want a callback when the new one is done.

This PR adds this state check in `finishSetup()` returning without action (except logging a warning) if the state is `STATE_DISPOSED`.
